### PR TITLE
Release: 0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,40 @@ Wrappers over the Java APIs for interacting with AWS. Depends on [pureharm](http
 
 Currently the project is under heavy development, and is mostly driven by company needs until a stable version can be put out. At the end of the day this is a principled utility library that provides all glue to make web server development a breeze.
 
+## sbt build
+Project published on `bintray`, so add the following to your build if you don't want to wait until maven central syncs:
+```scala
+resolvers ++= Seq(
+  Resolver.bintrayRepo("busymachines", "maven-releases"),
+  Resolver.bintrayRepo("busymachines", "maven-snapshots"),
+)
+```
+
+And then the available modules are:
+```scala
+val pureharmAWSVersion: String = "0.0.1" //https://github.com/busymachines/pureharm-aws/releases
+
+def pureharmAWS(m: String): ModuleID = "com.busymachines" %% s"pureharm-aws-$m" % pureharmAWSVersion
+
+val pureharmAWSCore:       ModuleID = pureharmAWS("core")       withSources ()
+val pureharmAWSS3:         ModuleID = pureharmAWS("s3")         withSources ()
+val pureharmAWSCloudfront: ModuleID = pureharmAWS("cloudfront") withSources ()
+val pureharmAWSLogger:     ModuleID = pureharmAWS("logger")     withSources ()
+
+//------- OR --------
+
+libraryDependencies ++= Seq(
+  "com.busymachines" %% s"pureharm-aws-core"       % pureharmAWSVersion,
+  "com.busymachines" %% s"pureharm-aws-s3"         % pureharmAWSVersion,
+  "com.busymachines" %% s"pureharm-aws-cloudfront" % pureharmAWSVersion,
+  "com.busymachines" %% s"pureharm-aws-logger"     % pureharmAWSVersion,
+)
+```
+
+## Usage
+Under construction. See [release notes](https://github.com/busymachines/pureharm-aws/releases) and tests for examples.
+
+
 ## Copyright and License
 
 All code is available to you under the Apache 2.0 license, available at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0) and also in the [LICENSE](./LICENSE) file.

--- a/aws-logger/src/it/scala/busymachines/pureharm/aws/logger/AWSLoggerLiveTest.scala
+++ b/aws-logger/src/it/scala/busymachines/pureharm/aws/logger/AWSLoggerLiveTest.scala
@@ -51,9 +51,9 @@ final class AWSLoggerLiveTest extends AnyFunSuite {
   private val fixture: Resource[IO, AWSLoggerFactory[IO]] = for {
     config     <- AWSLoggerConfig.fromNamespaceR[IO]("test-live.pureharm.aws.logger")
     blockingEC <- Pools.cached[IO]("aws-logger-block")
-    implicit0(b: BlockingShifter[IO]) <- BlockingShifter.fromExecutionContext[IO](blockingEC).pure[Resource[IO, ?]]
+    implicit0(b: BlockingShifter[IO]) <- BlockingShifter.fromExecutionContext[IO](blockingEC).pure[Resource[IO, *]]
     logFact <- AWSLoggerFactory.resource[IO](config)
-    _       <- cs.shift.to[Resource[IO, ?]] //shifting so that first parts of test are not run on scalatest-threads
+    _       <- cs.shift.to[Resource[IO, *]] //shifting so that first parts of test are not run on scalatest-threads
   } yield logFact
 
   test("... should send logs to AWS cloud") {

--- a/aws-s3/src/it/scala/busymachines/pureharm/aws/s3/S3LiveTest.scala
+++ b/aws-s3/src/it/scala/busymachines/pureharm/aws/s3/S3LiveTest.scala
@@ -48,7 +48,7 @@ final class S3LiveTest extends AnyFunSuite {
     for {
       config     <- S3Config.fromNamespaceR[IO]("test-live.pureharm.aws.s3")
       blockingEC <- Pools.cached[IO]("aws-block")
-      implicit0(b: BlockingShifter[IO]) <- BlockingShifter.fromExecutionContext[IO](blockingEC).pure[Resource[IO, ?]]
+      implicit0(b: BlockingShifter[IO]) <- BlockingShifter.fromExecutionContext[IO](blockingEC).pure[Resource[IO, *]]
       s3Client <- AmazonS3Client.resource[IO](config)
     } yield (config, s3Client)
 
@@ -72,7 +72,7 @@ final class S3LiveTest extends AnyFunSuite {
           got <- client.get(config.bucket, f1S3Key)
           _   <- l.info(s"2 — after GET — we got back: ${new String(got, UTF_8)}")
           _   <- l.info(s"2 — after GET — we expect: ${new String(f1_contents, UTF_8)}")
-          _   <- IO(assert(f1_contents.deep == got.deep)).onErrorF(l.info("comparison failed :(("))
+          _   <- IO(assert(f1_contents.toList == got.toList)).onErrorF(l.info("comparison failed :(("))
 
           _ <- l.info("---- deleting file ----")
           _ <- client.delete(config.bucket, f1S3Key)

--- a/build.sbt
+++ b/build.sbt
@@ -198,7 +198,7 @@ lazy val scalaCollCompatVersion: String = "2.1.2"     //https://github.com/scala
 lazy val shapelessVersion:       String = "2.3.3"     //https://github.com/milessabin/shapeless/releases
 lazy val catsVersion:            String = "2.0.0"     //https://github.com/typelevel/cats/releases
 lazy val catsEffectVersion:      String = "2.0.0"     //https://github.com/typelevel/cats-effect/releases
-lazy val fs2Version:             String = "1.1.0-M2"  //https://github.com/functional-streams-for-scala/fs2/releases
+lazy val fs2Version:             String = "2.0.0"     //https://github.com/functional-streams-for-scala/fs2/releases
 lazy val monixVersion:           String = "3.0.0"     //https://github.com/monix/monix/releases
 lazy val log4catsVersion:        String = "1.0.0"     //https://github.com/ChristopherDavenport/log4cats/releases
 

--- a/build.sbt
+++ b/build.sbt
@@ -201,16 +201,14 @@ lazy val catsEffectVersion:      String = "2.0.0"     //https://github.com/typel
 lazy val fs2Version:             String = "2.0.0"     //https://github.com/functional-streams-for-scala/fs2/releases
 lazy val monixVersion:           String = "3.0.0"     //https://github.com/monix/monix/releases
 lazy val log4catsVersion:        String = "1.0.0"     //https://github.com/ChristopherDavenport/log4cats/releases
-
-lazy val pureconfigVersion: String = "0.11.1" //https://github.com/pureconfig/pureconfig/releases
+lazy val pureconfigVersion:      String = "0.11.1"    //https://github.com/pureconfig/pureconfig/releases
+lazy val awsJavaSdkVersion:      String = "1.11.629"  //java — https://github.com/aws/aws-sdk-java/releases
+lazy val awsJavaSdkV2Version:    String = "2.8.5"     //java — https://github.com/aws/aws-sdk-java-v2/releases
 
 //these are used only for testing
 lazy val logbackVersion:   String = "1.2.3"        //https://github.com/qos-ch/logback/releases
 lazy val http4sVersion:    String = "0.21.0-M4"    //https://github.com/http4s/http4s/releases
 lazy val scalaTestVersion: String = "3.1.0-SNAP13" //https://github.com/scalatest/scalatest/releases
-
-lazy val awsJavaSdkVersion:   String = "1.11.629" //java — https://github.com/aws/aws-sdk-java/releases
-lazy val awsJavaSdkV2Version: String = "2.8.5"    //java — https://github.com/aws/aws-sdk-java-v2/releases
 
 //#############################################################################
 //################################### SCALA ###################################

--- a/build.sbt
+++ b/build.sbt
@@ -209,8 +209,8 @@ lazy val logbackVersion:   String = "1.2.3"        //https://github.com/qos-ch/l
 lazy val http4sVersion:    String = "0.21.0-M4"    //https://github.com/http4s/http4s/releases
 lazy val scalaTestVersion: String = "3.1.0-SNAP13" //https://github.com/scalatest/scalatest/releases
 
-lazy val awsJavaSdkVersion:   String = "1.11.625" //java — https://github.com/aws/aws-sdk-java/releases
-lazy val awsJavaSdkV2Version: String = "2.8.1"    //java — https://github.com/aws/aws-sdk-java-v2/releases
+lazy val awsJavaSdkVersion:   String = "1.11.629" //java — https://github.com/aws/aws-sdk-java/releases
+lazy val awsJavaSdkV2Version: String = "2.8.5"    //java — https://github.com/aws/aws-sdk-java-v2/releases
 
 //#############################################################################
 //################################### SCALA ###################################

--- a/build.sbt
+++ b/build.sbt
@@ -34,12 +34,12 @@
 
 addCommandAlias("build", ";compile;Test/compile")
 addCommandAlias("rebuild", ";clean;compile;Test/compile")
+addCommandAlias("it", "IntegrationTest / test")
 addCommandAlias("rebuild-update", ";clean;update;compile;Test/compile")
-addCommandAlias("ci", ";scalafmtCheck;rebuild-update;test")
+addCommandAlias("ci", ";scalafmtCheck;rebuild-update;test;it")
 addCommandAlias("ci-quick", ";scalafmtCheck;build;test")
 addCommandAlias("doLocal", ";clean;update;compile;publishLocal")
-addCommandAlias("doRelease", ";rebuild-update;publishSigned;sonatypeRelease")
-addCommandAlias("it", "IntegrationTest / test")
+addCommandAlias("doRelease", ";rebuild-update;publish;bintrayRelease")
 
 addCommandAlias("lint", ";scalafixEnable;rebuild;scalafix;scalafmtAll")
 
@@ -74,16 +74,14 @@ lazy val `aws-core-deps` = Seq(
 )
 
 lazy val `aws-core` = project
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     name := "pureharm-aws-core",
     libraryDependencies ++= `aws-core-deps`.distinct,
   )
-  .dependsOn(
-    )
-  .aggregate(
-    )
+  .dependsOn()
+  .aggregate()
 
 //#############################################################################
 lazy val `aws-s3-deps` =
@@ -105,7 +103,7 @@ lazy val `aws-s3-deps` =
 lazy val `aws-s3` = project
   .configs(IntegrationTest)
   .settings(Defaults.itSettings)
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     name := "pureharm-aws-s3",
@@ -139,7 +137,7 @@ lazy val `aws-cloudfront-deps` =
 lazy val `aws-cloudfront` = project
   .configs(IntegrationTest)
   .settings(Defaults.itSettings)
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     name := "pureharm-aws-cloudfront",
@@ -174,7 +172,7 @@ lazy val `aws-logger-deps` =
 lazy val `aws-logger` = project
   .configs(IntegrationTest)
   .settings(Defaults.itSettings)
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     name := "pureharm-aws-logger",
@@ -193,17 +191,17 @@ lazy val `aws-logger` = project
 //#############################################################################
 //#############################################################################
 
-lazy val pureharmVersion:        String = "0.0.2-RC1" //https://github.com/busymachines/pureharm/releases
-lazy val scalaCollCompatVersion: String = "2.1.2"     //https://github.com/scala/scala-collection-compat/releases
-lazy val shapelessVersion:       String = "2.3.3"     //https://github.com/milessabin/shapeless/releases
-lazy val catsVersion:            String = "2.0.0"     //https://github.com/typelevel/cats/releases
-lazy val catsEffectVersion:      String = "2.0.0"     //https://github.com/typelevel/cats-effect/releases
-lazy val fs2Version:             String = "2.0.0"     //https://github.com/functional-streams-for-scala/fs2/releases
-lazy val monixVersion:           String = "3.0.0"     //https://github.com/monix/monix/releases
-lazy val log4catsVersion:        String = "1.0.0"     //https://github.com/ChristopherDavenport/log4cats/releases
-lazy val pureconfigVersion:      String = "0.11.1"    //https://github.com/pureconfig/pureconfig/releases
-lazy val awsJavaSdkVersion:      String = "1.11.629"  //java — https://github.com/aws/aws-sdk-java/releases
-lazy val awsJavaSdkV2Version:    String = "2.8.5"     //java — https://github.com/aws/aws-sdk-java-v2/releases
+lazy val pureharmVersion:        String = "0.0.2"    //https://github.com/busymachines/pureharm/releases
+lazy val scalaCollCompatVersion: String = "2.1.2"    //https://github.com/scala/scala-collection-compat/releases
+lazy val shapelessVersion:       String = "2.3.3"    //https://github.com/milessabin/shapeless/releases
+lazy val catsVersion:            String = "2.0.0"    //https://github.com/typelevel/cats/releases
+lazy val catsEffectVersion:      String = "2.0.0"    //https://github.com/typelevel/cats-effect/releases
+lazy val fs2Version:             String = "2.0.0"    //https://github.com/functional-streams-for-scala/fs2/releases
+lazy val monixVersion:           String = "3.0.0"    //https://github.com/monix/monix/releases
+lazy val log4catsVersion:        String = "1.0.0"    //https://github.com/ChristopherDavenport/log4cats/releases
+lazy val pureconfigVersion:      String = "0.11.1"   //https://github.com/pureconfig/pureconfig/releases
+lazy val awsJavaSdkVersion:      String = "1.11.629" //java — https://github.com/aws/aws-sdk-java/releases
+lazy val awsJavaSdkV2Version:    String = "2.8.5"    //java — https://github.com/aws/aws-sdk-java-v2/releases
 
 //these are used only for testing
 lazy val logbackVersion:   String = "1.2.3"        //https://github.com/qos-ch/logback/releases
@@ -238,7 +236,7 @@ lazy val pureharmConfig:           ModuleID = pureharm("config")            with
 //#############################################################################
 
 //https://github.com/typelevel/cats/releases
-lazy val catsCore:    ModuleID = "org.typelevel" %% "cats-core"    % catsVersion withSources ()
+lazy val catsCore: ModuleID = "org.typelevel" %% "cats-core" % catsVersion withSources ()
 
 //https://github.com/typelevel/cats-effect/releases
 lazy val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % catsEffectVersion withSources ()

--- a/build.sbt
+++ b/build.sbt
@@ -200,7 +200,7 @@ lazy val catsVersion:            String = "2.0.0"     //https://github.com/typel
 lazy val catsEffectVersion:      String = "2.0.0"     //https://github.com/typelevel/cats-effect/releases
 lazy val fs2Version:             String = "1.1.0-M2"  //https://github.com/functional-streams-for-scala/fs2/releases
 lazy val monixVersion:           String = "3.0.0-RC5" //https://github.com/monix/monix/releases
-lazy val log4catsVersion:        String = "1.0.0-RC3" //https://github.com/ChristopherDavenport/log4cats/releases
+lazy val log4catsVersion:        String = "1.0.0"     //https://github.com/ChristopherDavenport/log4cats/releases
 
 lazy val pureconfigVersion: String = "0.11.1" //https://github.com/pureconfig/pureconfig/releases
 

--- a/build.sbt
+++ b/build.sbt
@@ -199,7 +199,7 @@ lazy val shapelessVersion:       String = "2.3.3"     //https://github.com/miles
 lazy val catsVersion:            String = "2.0.0"     //https://github.com/typelevel/cats/releases
 lazy val catsEffectVersion:      String = "2.0.0"     //https://github.com/typelevel/cats-effect/releases
 lazy val fs2Version:             String = "1.1.0-M2"  //https://github.com/functional-streams-for-scala/fs2/releases
-lazy val monixVersion:           String = "3.0.0-RC5" //https://github.com/monix/monix/releases
+lazy val monixVersion:           String = "3.0.0"     //https://github.com/monix/monix/releases
 lazy val log4catsVersion:        String = "1.0.0"     //https://github.com/ChristopherDavenport/log4cats/releases
 
 lazy val pureconfigVersion: String = "0.11.1" //https://github.com/pureconfig/pureconfig/releases

--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -25,7 +25,7 @@ import Keys._
   *
   */
 object CompilerSettings {
-  lazy val scala2_12:        String = "2.12.9"
+  lazy val scala2_12:        String = "2.12.10"
   lazy val scala2_13:        String = "2.13.0"
   lazy val mainScalaVersion: String = scala2_12
 

--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -27,7 +27,7 @@ import Keys._
 object CompilerSettings {
   lazy val scala2_12:        String = "2.12.10"
   lazy val scala2_13:        String = "2.13.0"
-  lazy val mainScalaVersion: String = scala2_12
+  lazy val mainScalaVersion: String = scala2_13
 
   def compilerSettings: Seq[Setting[_]] =
     Seq(

--- a/project/PublishingSettings.scala
+++ b/project/PublishingSettings.scala
@@ -18,69 +18,51 @@
 import sbt._
 import Keys._
 import com.typesafe.sbt.SbtPgp.autoImportImpl._
-import xerial.sbt.Sonatype.SonatypeKeys._
+import bintray.BintrayKeys._
 
 /**
-  * All instructions for publishing to sonatype can be found on the sbt-plugin page:
-  * http://www.scala-sbt.org/release/docs/Using-Sonatype.html
+  * Publishing is done to bintray — to this org:
+  * https://bintray.com/busymachines/maven-releases
   *
-  * and some here:
+  * To set up bintray, just look at a combination of two docs:
+  * https://github.com/sbt/sbt-bintray and a more user friendly:
+  * http://queirozf.com/entries/publishing-an-sbt-project-onto-bintray-an-example
   *
-  * https://github.com/xerial/sbt-sonatype
+  * TL;DR:
+  * 1. create bintray account: https://bintray.com/
+  * 2. request to be added as a member to busymachines organization : https://bintray.com/busymachines
+  * 3. set your ~/.bintray/.credentials file to contain:
+  * {{{
+  * realm = Bintray API Realm
+  * host = api.bintray.com
+  * user = ${username that has publishing access to busymachines bintray org linked above}
+  * password = ${get password by generating an API Key from the bintray UI}
+  * }}}
   *
-  * VERY IMPORTANT!!! You need to add credentials as described here:
-  * http://www.scala-sbt.org/release/docs/Using-Sonatype.html#Second+-+Configure+Sonatype+integration
-  *
+  * N.B. for historical purposes
+  * For sync-ing to maven central you need to setup bintray to communicate via sonatype with
+  * maven central. Quite complicated honestly. Should already be set-up at this point.
+  * Anyway, the issue that gives you access to sonatype via which you can sync to maven central is here:
   * The username and password are the same as those to the Sonatype JIRA account.
   * https://issues.sonatype.org/browse/OSSRH-33718
-  *
-  * And then you need to ensure PGP keys to sign the maven artifacts:
-  * http://www.scala-sbt.org/release/docs/Using-Sonatype.html#PGP+Tips%E2%80%99n%E2%80%99tricks
-  * Which means that you need to have PGP installed
-  *
-  * To avoid pushing sensitive information to github you must put all PGP related things in your local configs:
-  * as described here:
-  *
-  * https://github.com/sbt/sbt-pgp/issues/69
   */
 object PublishingSettings {
 
-  def sonatypeSettings: Seq[Setting[_]] = Seq(
-    useGpg                     := true,
-    sonatypeProfileName        := Settings.organizationName,
-    publishArtifact in Compile := true,
-    publishArtifact in Test    := false,
-    publishMavenStyle          := true,
-    pomIncludeRepository       := (_ => false),
-    publishTo := Option {
-      if (isSnapshot.value)
-        Opts.resolver.sonatypeSnapshots
-      else
-        Opts.resolver.sonatypeStaging
-    },
-    licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
-    scmInfo := Option(
-      ScmInfo(
-        url("https://github.com/busymachines/pureharm"),
-        "scm:git@github.com:busymachines/pureharm.git",
-      ),
-    ),
-    developers := List(
-      Developer(
-        id    = "lorandszakacs",
-        name  = "Lorand Szakacs",
-        email = "lorand.szakacs@busymachines.com",
-        url   = url("https://github.com/lorandszakacs"),
-      ),
-    ),
+  def bintraySettings: Seq[Setting[_]] = Seq(
+    licenses                := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
+    bintrayOrganization     := Some("busymachines"),
+    bintrayRepository       := { if (isSnapshot.value) "maven-snapshots" else "maven-releases" },
+    bintrayReleaseOnPublish := false,
+    bintrayPackageLabels    := Seq("scala", "pureharm-aws", "busymachines"),
   )
 
   def noPublishSettings: Seq[Setting[_]] = Seq(
-    publish              := {},
-    publishLocal         := {},
-    skip in publishLocal := true,
-    skip in publish      := true,
-    publishArtifact      := false,
+    publish                := {},
+    publishLocal           := {},
+    skip in publishLocal   := true,
+    skip in publish        := true,
+    skip in bintrayRelease := true,
+    publishArtifact        := false,
   )
 
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -27,5 +27,9 @@ object Settings {
     Seq(
       organization := organizationName,
       homepage     := Some(url(pureharmHomepage)),
+      resolvers ++= Seq(
+        Resolver.bintrayRepo("busymachines", "maven-releases"),
+        Resolver.bintrayRepo("busymachines", "maven-snapshots"),
+      ),
     ) ++ CompilerSettings.compilerSettings
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,14 +16,15 @@
   * limitations under the License.
   */
 /**
-  * Helps us publish the artifacts to sonatype, which in turn
-  * pushes to maven central. Please follow instructions of setting
-  * up as described in:
-  * http://busymachines.github.io/busymachines-commons/docs/publishing-artifacts.html
+  * Helps us publish the artifacts to bintray, which in turn
+  * pushes to maven central.
+  * 
+  * See this guide for help:
+  * http://queirozf.com/entries/publishing-an-sbt-project-onto-bintray-an-example
   *
-  * https://github.com/xerial/sbt-sonatype/releases
+  * https://github.com/sbt/sbt-bintray/releases
   */
-  addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.0") //https://github.com/xerial/sbt-sonatype/releases
+  addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
 
   /**
     *

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.1"
+version in ThisBuild := "0.0.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.1-SNAPSHOT"
+version in ThisBuild := "0.0.1"


### PR DESCRIPTION
Cross compiled to scala `2.12` and `2.13`
Depends on stable versions of the typelevel ecosystem, and on stable pureharm version `0.0.2`.

Direct dependencies:
- [x] monix-catnap `3.0.0`
- [x] log4cats `1.0.0`
- [x] `"com.amazonaws" % "aws-java-sdk-cloudfront" % "1.11.629"`
- [x] `"com.amazonaws" % "aws-java-sdk-logs"           % "1.11.629"`

- [x] `"software.amazon.awssdk" % "regions" % "2.8.5"`
- [x] `"software.amazon.awssdk" % "s3"         % "2.8.5"`

Transitive dependencies:

- [x] cats-core `2.0.0`
- [x] cats-effect `2.0.0`
- [x] pureconfig `0.11.1`