### PR TITLE
Add region to sns config

### DIFF
--- a/aws-sns/src/main/scala/busymachines/pureharm/aws/sns/SNSMobilePushConfig.scala
+++ b/aws-sns/src/main/scala/busymachines/pureharm/aws/sns/SNSMobilePushConfig.scala
@@ -1,5 +1,6 @@
 package busymachines.pureharm.aws.sns
 
+import busymachines.pureharm.aws.core.AmazonRegion
 import pureconfig.ConfigReader
 
 import scala.concurrent.duration.FiniteDuration
@@ -11,8 +12,9 @@ import scala.concurrent.duration.FiniteDuration
   *
   */
 case class SNSMobilePushConfig(
-  accessKeyID:             SNSAccessKeyID,
-  secretAccessKey:         SNSSecretAccessKey,
+  accessKeyID:                SNSAccessKeyID,
+  secretAccessKey:            SNSSecretAccessKey,
+  region:                     AmazonRegion,
   applicationARN:             SNSPlatformApplicationARN,
   arnEndpointCreationRetries: Int,
   arnEndpointCreationTimeout: FiniteDuration,

--- a/aws-sns/src/main/scala/busymachines/pureharm/aws/sns/SNSMobilePushNotificationsOps.scala
+++ b/aws-sns/src/main/scala/busymachines/pureharm/aws/sns/SNSMobilePushNotificationsOps.scala
@@ -1,5 +1,6 @@
 package busymachines.pureharm.aws.sns
 
+import busymachines.pureharm.aws.core.AmazonRegion
 import busymachines.pureharm.aws.sns._
 import busymachines.pureharm.effects._
 import busymachines.pureharm.effects.implicits._
@@ -138,6 +139,7 @@ object SNSMobilePushNotificationsOps {
             StaticCredentialsProvider
               .create(AwsBasicCredentials.create(config.accessKeyID, config.secretAccessKey)),
           )
+          .region(AmazonRegion.toSDKRegion(config.region))
           .build()
       }
       .map(jSNSClient => new SNSMobilePushNotificationsOps[F](jSNSClient))


### PR DESCRIPTION
Since sns configuration requires a region, we should give one explicitly, else we end up with weird configuration bugs. e.g. sns figures out region based on aws cli logged in profile