### PR TITLE
Feature: better cloudfront config

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -21,7 +21,7 @@
 #
 
 #https://github.com/scalameta/scalafmt/releases
-version = 2.6.3
+version = 2.6.4
 
 project {
   #if you don't specify that files ending in .scala .sbt with $,

--- a/aws-cloudfront/src/it/resources/reference.conf
+++ b/aws-cloudfront/src/it/resources/reference.conf
@@ -20,7 +20,7 @@ test-live.pureharm.aws {
     api-call-timeout = ${?LIVE_TEST_PUREHARM_AWS_API_CALL_TIMEOUT}
   }
 
-  cloudfront {
+  cloudfront-key-path {
     #see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html
     distribution-domain = "xyz.cloudfront.net"
     distribution-domain = ${?LIVE_TEST_PUREHARM_AWS_CLOUDFRONT_DISTRIBUTION_DOMAIN}
@@ -30,6 +30,27 @@ test-live.pureharm.aws {
     # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html#private-content-creating-cloudfront-key-pairs-procedure
     private-key-file-path = "secret-access-key-not-committing-it-to-github-lol"
     private-key-file-path = ${?LIVE_TEST_PUREHARM_AWS_CLOUDFRONT_KEY_FILE_PATH}
+
+    #see https://support.s3mediamaestro.com/article/204-how-to-obtain-your-cloudfront-key-pair-id-and-private-key
+    key-pair-id = "not-committing-it-to-github-lol"
+    key-pair-id = ${?LIVE_TEST_PUREHARM_AWS_CLOUDFRONT_KEY_PAIR_ID}
+
+    url-expiration-time = 5 minutes
+    url-expiration-time = ${?LIVE_TEST_PUREHARM_AWS_CLOUDFRONT_URL_EXPIRATION_TIME}
+  }
+
+  cloudfront-key-value {
+    #see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html
+    distribution-domain = "xyz.cloudfront.net"
+    distribution-domain = ${?LIVE_TEST_PUREHARM_AWS_CLOUDFRONT_DISTRIBUTION_DOMAIN}
+
+    #see https://support.s3mediamaestro.com/article/204-how-to-obtain-your-cloudfront-key-pair-id-and-private-key
+    # see on how to generate keys that are compatible with cloudfront:
+    # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html#private-content-creating-cloudfront-key-pairs-procedure
+    private-key = "secret-access-key-not-committing-it-to-github-lol—this should be a base64 encoded string of the file"
+    private-key = ${?LIVE_TEST_PUREHARM_AWS_CLOUDFRONT_KEY_FILE_BASE64_VALUE}
+
+    private-key-format = ".pem"
 
     #see https://support.s3mediamaestro.com/article/204-how-to-obtain-your-cloudfront-key-pair-id-and-private-key
     key-pair-id = "not-committing-it-to-github-lol"

--- a/aws-cloudfront/src/it/scala/busymachines/pureharm/aws/cloudfront/CloudfrontLiveURLSigningTest.scala
+++ b/aws-cloudfront/src/it/scala/busymachines/pureharm/aws/cloudfront/CloudfrontLiveURLSigningTest.scala
@@ -78,7 +78,7 @@ final class CloudfrontLiveURLSigningTest extends PureharmTestWithResource {
     s3Client    <- AmazonS3Client.resource[IO](config)
     cfConfig    <- CloudfrontConfig.fromNamespaceR[IO]("test-live.pureharm.aws.cloudfront")
     _           <- Resource.liftF(l.info(s"CFCONFIG: $cfConfig"))
-    cfClient    <- CloudfrontURLSigner[IO](cfConfig).pure[Resource[IO, *]]
+    cfClient    <- CloudfrontURLSigner[IO](cfConfig)
     _           <- runtime.contextShift.shift.to[Resource[IO, *]] //shifting so that logs are not run on scalatest threads
   } yield (blazeClient, config, s3Client, cfClient)
 

--- a/aws-cloudfront/src/it/scala/busymachines/pureharm/aws/cloudfront/CloudfrontLiveURLSigningTestKeyPath.scala
+++ b/aws-cloudfront/src/it/scala/busymachines/pureharm/aws/cloudfront/CloudfrontLiveURLSigningTestKeyPath.scala
@@ -65,7 +65,7 @@ import scala.concurrent.duration._
   * @author Lorand Szakacs, https://github.com/lorandszakacs
   * @since 19 Jul 2019
   */
-final class CloudfrontLiveURLSigningTest extends PureharmTestWithResource {
+final class CloudfrontLiveURLSigningTestKeyPath extends PureharmTestWithResource {
 
   implicit private val l: Logger[IO] = Slf4jLogger.getLogger[IO]
 
@@ -76,7 +76,7 @@ final class CloudfrontLiveURLSigningTest extends PureharmTestWithResource {
     blazeClient <-
       BlazeClientBuilder[IO](runtime.blocker.blockingContext).withResponseHeaderTimeout(10.seconds).resource
     s3Client    <- AmazonS3Client.resource[IO](config)
-    cfConfig    <- CloudfrontConfig.fromNamespaceR[IO]("test-live.pureharm.aws.cloudfront")
+    cfConfig    <- CloudfrontConfig.fromNamespaceR[IO]("test-live.pureharm.aws.cloudfront-key-path")
     _           <- Resource.liftF(l.info(s"CFCONFIG: $cfConfig"))
     cfClient    <- CloudfrontURLSigner[IO](cfConfig)
     _           <- runtime.contextShift.shift.to[Resource[IO, *]] //shifting so that logs are not run on scalatest threads

--- a/aws-cloudfront/src/it/scala/busymachines/pureharm/aws/cloudfront/CloudfrontLiveURLSigningTestKeyValue.scala
+++ b/aws-cloudfront/src/it/scala/busymachines/pureharm/aws/cloudfront/CloudfrontLiveURLSigningTestKeyValue.scala
@@ -1,0 +1,116 @@
+package busymachines.pureharm.aws.cloudfront
+
+import busymachines.pureharm.aws.s3._
+import busymachines.pureharm.effects._
+import busymachines.pureharm.effects.implicits._
+import busymachines.pureharm.testkit._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.http4s.client.Client
+import org.http4s.client.blaze._
+
+import scala.concurrent.duration._
+
+/**
+  * --- IGNORED BY DEFAULT — test expects proper live amazon config ---
+  *
+  * Before running this ensure that you actually have the proper local environment
+  * variables. See the ``pureharm-aws/aws-cloudfront/src/test/resources/reference.conf``
+  * for the environment variables that are used by this test.
+  *
+  * We can't commit to github the proper configuration to make this run.
+  *
+  * GIVEN $REGION=?eu-west-1 or whatever
+  * The idea is:
+  * 1. You need an S3 bucket without public access, call it $S3_BUCKET
+  *    https://s3.console.aws.amazon.com/s3/home?region=$REGION
+  * 2. Create a cloudfront distribution that uses your S3 bucket as the origin
+  *    https://console.aws.amazon.com/cloudfront/home?region=$REGION#distributions:
+  *    call it $CLOUDFRONT_DIST
+  * 3. FOR NOW, make sure that the "Behaviors" tab of the above $CLOUDFRONT_DIST the
+  *    trusted signers is set to "no", "nothing", "none". For now, can't figure out
+  *    why it doesn't work with it.
+  * 4. Create an Origin Access Identity(OAI)for $CLOUDFRONT_DIST, called $OAI
+  *    https://console.aws.amazon.com/cloudfront/home?region=eu-central-1#oai:
+  * 4.1 and assign this OAI to have access to your S3. Either select the radio button "Yes, update bucket permissions"
+  *    or do step 5, manually:
+  * 5. OPTIONAL — Make sure that your $S3_BUCKET bucket policies is configured to allow reads from
+  *    your cloudfront distribution
+  *    https://s3.console.aws.amazon.com/s3/buckets/$S3_BUCKET/?region=$REGION&tab=permissions
+  *
+  *    It should looks something like:
+  *    {{{
+  * {
+  *     "Version": "2012-10-17",
+  *     "Id": "PolicyForCloudFrontPrivateContent",
+  *     "Statement": [
+  *         {
+  *             "Sid": " 1",
+  *             "Effect": "Allow",
+  *             "Principal": {
+  *                 "AWS": "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity $OAI"
+  *             },
+  *             "Action": "s3:GetObject",
+  *             "Resource": "arn:aws:s3:::$S3_BUCKET/$STAR_CHAR_CANNOT_USE_IT_BECAUSE_COMMENT"
+  *         }
+  *     ]
+  * }
+  * }}}
+  *
+  * Then, ensure that your root user for the amazon account, created a cloudfront key/pair ID, and provides you with
+  * its id, required for the [[busymachines.pureharm.aws.cloudfront.CloudfrontKeyPairID]].
+  *
+  * @author Lorand Szakacs, https://github.com/lorandszakacs
+  * @since 19 Jul 2019
+  */
+final class CloudfrontLiveURLSigningTestKeyValue extends PureharmTestWithResource {
+
+  implicit private val l: Logger[IO] = Slf4jLogger.getLogger[IO]
+
+  override type ResourceType = (Client[IO], S3Config, AmazonS3Client[IO], CloudfrontURLSigner[IO])
+
+  override def resource(meta: MetaData): Resource[IO, ResourceType] = for {
+    config      <- S3Config.fromNamespaceR[IO]("test-live.pureharm.aws.s3")
+    blazeClient <-
+      BlazeClientBuilder[IO](runtime.blocker.blockingContext).withResponseHeaderTimeout(10.seconds).resource
+    s3Client    <- AmazonS3Client.resource[IO](config)
+    cfConfig    <- CloudfrontConfig.fromNamespaceR[IO]("test-live.pureharm.aws.cloudfront-key-value")
+    _           <- Resource.liftF(l.info(s"CFCONFIG: $cfConfig"))
+    cfClient    <- CloudfrontURLSigner[IO](cfConfig)
+    _           <- runtime.contextShift.shift.to[Resource[IO, *]] //shifting so that logs are not run on scalatest threads
+  } yield (blazeClient, config, s3Client, cfClient)
+
+  private val s3KeyIO: IO[S3FileKey] = S3FileKey("aws_live_test", "subfolder", "google_murray_bookchin.txt").liftTo[IO]
+
+  private val fileContent: S3BinaryContent = S3BinaryContent(
+    "GOOGLE_MURRAY_BOOKCHIN".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+  )
+
+  test("s3 upload + signed url delivery via cloudfront") {
+    case (http4sClient, s3Config, s3Client, cfSigner) =>
+      for {
+        s3Key        <- s3KeyIO
+        _            <- l.info(s"Uploaded file to s3: $s3Key")
+        _            <-
+          s3Client
+            .put(s3Config.bucket, s3Key, fileContent)
+            .onError { case e => l.error(e)(s"PUT failed w/: $e") }
+            .void
+            .handleErrorWith(_ => IO(fail("1. failed to upload file to s3")))
+
+        checkingFile <- s3Client.get(s3Config.bucket, s3Key)
+        _            <- l.info(s"Fetched file from s3: $s3Key")
+        _            <- IO(assert(fileContent.toList == checkingFile.toList)).onErrorF(l.info("checking file via S3 get failed"))
+        _            <- l.info(s"File from s3 is all OK: $s3Key")
+
+        signedURL       <- cfSigner.signS3KeyCanned(s3Key)
+        _               <- l.info(s"Signed url: $signedURL")
+        bytesFromSigned <- http4sClient.get(signedURL)(response => response.body.compile.toList)
+        _               <- l.info(s"Fetched  #${bytesFromSigned.size} bytes from: GET $signedURL")
+        _               <- l.info(s"Expected #${fileContent.size} bytes")
+        _               <- IO(assert(fileContent.toList == bytesFromSigned))
+          .onErrorF(l.info("comparison failed for bytes from URL"))
+      } yield succeed
+  }
+
+}

--- a/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/CloudfrontConfig.scala
+++ b/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/CloudfrontConfig.scala
@@ -7,16 +7,52 @@ import busymachines.pureharm.config._
   * @author Lorand Szakacs, https://github.com/lorandszakacs
   * @since 08 Jul 2019
   */
-final case class CloudfrontConfig(
-  distributionDomain: CloudfrontDistributionDomain,
-  privateKeyFilePath: CloudfrontPrivateKeyFilePath,
-  keyPairID:          CloudfrontKeyPairID,
-  urlExpirationTime:  CloudfrontURLExpiration,
-)
+sealed trait CloudfrontConfig
 
 object CloudfrontConfig extends ConfigLoader[CloudfrontConfig] {
   import busymachines.pureharm.config.implicits._
+  import busymachines.pureharm.effects.implicits._
+  import pureconfig.error.CannotConvert
 
-  implicit override def configReader: ConfigReader[CloudfrontConfig] = semiauto.deriveReader[CloudfrontConfig]
-  override def default[F[_]](implicit F: Sync[F]): F[CloudfrontConfig] = this.load("pureharm.aws.cloudfront")
+  final case class WithKeyFile(
+    distributionDomain: CloudfrontDistributionDomain,
+    privateKeyFilePath: CloudfrontPrivateKeyFilePath,
+    keyPairID:          CloudfrontKeyPairID,
+    urlExpirationTime:  CloudfrontURLExpiration,
+  ) extends CloudfrontConfig
+
+  final case class WithPrivateKey(
+    distributionDomain: CloudfrontDistributionDomain,
+    keyPairID:          CloudfrontKeyPairID,
+    privateKey:         CloudfrontPrivateKey,
+    privateKeyFormat:   CloudfrontPrivateKey.Format,
+    urlExpirationTime:  CloudfrontURLExpiration,
+  ) extends CloudfrontConfig
+
+  //TODO: add safe phantom type support in pureconfig
+  implicit protected val privateKeyReader: ConfigReader[CloudfrontPrivateKey] =
+    ConfigReader[String].emap(s =>
+      CloudfrontPrivateKey(s).leftMap(an =>
+        CannotConvert(
+          value   = s"CloudfrontPrivateKeyValue — truncated(10): ${s.take(20)}",
+          toType  = "CloudfrontPrivateKey",
+          because = an.toString,
+        )
+      )
+    )
+
+  implicit protected val formatReader: ConfigReader[CloudfrontPrivateKey.Format]  =
+    semiauto.deriveEnumerationReader(transformName = n => n.toLowerCase.prepended('.'))
+
+  implicit private val withKeyFileCFG: ConfigReader[CloudfrontConfig.WithKeyFile] =
+    semiauto.deriveReader[CloudfrontConfig.WithKeyFile]
+
+  implicit private val withPrivateKeyCFG: ConfigReader[CloudfrontConfig.WithPrivateKey] =
+    semiauto.deriveReader[CloudfrontConfig.WithPrivateKey]
+
+  implicit override val configReader: ConfigReader[CloudfrontConfig] =
+    withPrivateKeyCFG.orElse(withKeyFileCFG)
+
+  override def default[F[_]](implicit F: Sync[F]): F[CloudfrontConfig] =
+    this.load("pureharm.aws.cloudfront")
 }

--- a/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/CloudfrontConfig.scala
+++ b/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/CloudfrontConfig.scala
@@ -7,7 +7,11 @@ import busymachines.pureharm.config._
   * @author Lorand Szakacs, https://github.com/lorandszakacs
   * @since 08 Jul 2019
   */
-sealed trait CloudfrontConfig
+sealed trait CloudfrontConfig {
+  def distributionDomain: CloudfrontDistributionDomain
+  def keyPairID:          CloudfrontKeyPairID
+  def urlExpirationTime:  CloudfrontURLExpiration
+}
 
 object CloudfrontConfig extends ConfigLoader[CloudfrontConfig] {
   import busymachines.pureharm.config.implicits._
@@ -15,18 +19,18 @@ object CloudfrontConfig extends ConfigLoader[CloudfrontConfig] {
   import pureconfig.error.CannotConvert
 
   final case class WithKeyFile(
-    distributionDomain: CloudfrontDistributionDomain,
-    privateKeyFilePath: CloudfrontPrivateKeyFilePath,
-    keyPairID:          CloudfrontKeyPairID,
-    urlExpirationTime:  CloudfrontURLExpiration,
+    override val distributionDomain: CloudfrontDistributionDomain,
+    override val keyPairID:          CloudfrontKeyPairID,
+    override val urlExpirationTime:  CloudfrontURLExpiration,
+    val privateKeyFilePath:          CloudfrontPrivateKeyFilePath,
   ) extends CloudfrontConfig
 
   final case class WithPrivateKey(
-    distributionDomain: CloudfrontDistributionDomain,
-    keyPairID:          CloudfrontKeyPairID,
-    privateKey:         CloudfrontPrivateKey,
-    privateKeyFormat:   CloudfrontPrivateKey.Format,
-    urlExpirationTime:  CloudfrontURLExpiration,
+    override val distributionDomain: CloudfrontDistributionDomain,
+    override val keyPairID:          CloudfrontKeyPairID,
+    override val urlExpirationTime:  CloudfrontURLExpiration,
+    privateKey:                      CloudfrontPrivateKey,
+    privateKeyFormat:                CloudfrontPrivateKey.Format,
   ) extends CloudfrontConfig
 
   //TODO: add safe phantom type support in pureconfig

--- a/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/CloudfrontPrivateKey.scala
+++ b/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/CloudfrontPrivateKey.scala
@@ -1,0 +1,33 @@
+package busymachines.pureharm.aws.cloudfront
+
+import busymachines.pureharm.phantom._
+
+/**
+  * The key has to be base64 encoded and will be checked
+  */
+object CloudfrontPrivateKey extends SafePhantomType[Throwable, String] {
+
+  override def check(value: String): Either[Throwable, String] = {
+    import java.nio.charset.StandardCharsets
+    import java.util.Base64
+    import busymachines.pureharm.effects.implicits._
+    Either.catchNonFatal(new String(Base64.getDecoder.decode(value), StandardCharsets.UTF_8))
+  }
+
+  sealed trait Format
+
+  implicit class Ops(pk: CloudfrontPrivateKey) {
+
+    def utf8Bytes: Array[Byte] = pk.getBytes(
+      java.nio.charset.StandardCharsets.UTF_8
+    )
+  }
+
+  case object PEM extends Format {
+    override def toString: String = ".pem"
+  }
+
+  case object DER extends Format {
+    override def toString: String = ".der"
+  }
+}

--- a/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/CloudfrontURLSigner.scala
+++ b/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/CloudfrontURLSigner.scala
@@ -1,6 +1,7 @@
 package busymachines.pureharm.aws.cloudfront
 
 import busymachines.pureharm.effects._
+import busymachines.pureharm.effects.implicits._
 import busymachines.pureharm.aws.s3._
 
 /**
@@ -17,13 +18,29 @@ trait CloudfrontURLSigner[F[_]] {
 
 object CloudfrontURLSigner {
 
-  def apply[F[_]: Sync: BlockingShifter](config: CloudfrontConfig): CloudfrontURLSigner[F] =
-    new impl.CloudfrontURLSignerImpl[F](config)
-
-  import busymachines.pureharm.effects.implicits._
+  def apply[F[_]: Sync: BlockingShifter](config: CloudfrontConfig): Resource[F, CloudfrontURLSigner[F]] =
+    config match {
+      case kf: CloudfrontConfig.WithKeyFile    => new impl.CloudfrontURLSignerImpl[F](kf).pure[Resource[F, *]]
+      case pk: CloudfrontConfig.WithPrivateKey =>
+        for {
+          (keyPath, _) <- Resource.make[F, (CloudfrontPrivateKeyFilePath, java.nio.file.Path)](
+            acquire = init.writePrivateKeyToTempFile[F](pk.privateKey, pk.privateKeyFormat)
+          )(
+            release = {
+              case (kp, td) => init.deletePrivateKeyTempFile[F](td, kp)
+            }
+          )
+          newConfig = CloudfrontConfig.WithKeyFile(
+            distributionDomain = pk.distributionDomain,
+            privateKeyFilePath = keyPath,
+            keyPairID          = pk.keyPairID,
+            urlExpirationTime  = pk.urlExpirationTime,
+          )
+        } yield new impl.CloudfrontURLSignerImpl[F](newConfig)
+    }
 
   def signS3KeyCanned[F[_]: Sync: BlockingShifter](
-    config: CloudfrontConfig
+    config: CloudfrontConfig.WithKeyFile
   )(s3key:  S3FileKey): F[CloudfrontSignedURL] =
     for {
       baseURL    <- impl.createBaseUrl(config.distributionDomain)(s3key).pure[F]
@@ -37,7 +54,68 @@ object CloudfrontURLSigner {
       )
     } yield CloudfrontSignedURL(signed)
 
-  private[cloudfront] object impl {
+  private object init {
+    import java.nio.file._
+    import java.nio.file.attribute._
+
+    /**
+      * Basically the way this works is that it:
+      *  - create a $folderName with a random name under /tmp
+      *    this folder has permissions 600 (it has to be lower than 644).
+      *    we use a random name in case of server crashes or something,
+      *    so we don't have conflicts.
+      *
+      *  - create a /tmp/$folderName/temp_private_key.${pem or der)
+      *    to store the decoded `privateKey` with permissions 600
+      *
+      *  This permission scheme is how you _have_ to store private keys :)
+      *
+      * @param privateKey
+      *   The private key to be stored in a file
+      *  @param privateKeyFormat
+      *    one of .pem or .der
+      * @return
+      *   The full file path to be read w/ the cloudfront java SDK
+      */
+    def writePrivateKeyToTempFile[F[_]](
+      privateKey:       CloudfrontPrivateKey,
+      privateKeyFormat: CloudfrontPrivateKey.Format,
+    )(implicit
+      F:                Sync[F],
+      bs:               BlockingShifter[F],
+    ): F[(CloudfrontPrivateKeyFilePath, Path)] = {
+
+      val tempDirRoot = Path.of("/tmp")
+      val perms600: java.util.Set[PosixFilePermission] = {
+        val temp = new java.util.HashSet[PosixFilePermission]()
+        temp.add(PosixFilePermission.OWNER_READ);
+        temp.add(PosixFilePermission.OWNER_WRITE);
+        temp
+      }
+      val attr        = PosixFilePermissions.asFileAttribute(perms600)
+      val write       = for {
+        tempDirPath <- F.delay(Files.createTempDirectory(tempDirRoot, "cloudfront_key", attr)) //TODO: adapt errors
+        tempKeyFilePath = Path.of(tempDirRoot.toString, s"temp_private_key${privateKeyFormat.toString}")
+        afterWrite <- F.delay(Files.createTempFile(tempKeyFilePath, null, null, attr))
+        finalPath  <- F.delay[Path](
+          Files.write(afterWrite, privateKey.utf8Bytes, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
+        )
+      } yield (CloudfrontPrivateKeyFilePath(finalPath.toAbsolutePath.toString), tempDirPath)
+
+      bs.blockOn(write)
+    }
+
+    def deletePrivateKeyTempFile[F[_]: Sync: BlockingShifter](
+      tempDirPath: Path,
+      kfp:         CloudfrontPrivateKeyFilePath,
+    ): F[Unit] =
+      BlockingShifter[F].blockOn {
+        Sync[F].delay(Files.delete(Path.of(kfp))) >> Sync[F].delay(Files.delete(tempDirPath))
+      }
+
+  }
+
+  private object impl {
     import java.security.PrivateKey
     import com.amazonaws.services.cloudfront.CloudFrontUrlSigner
     import com.amazonaws.services.cloudfront.util.SignerUtils
@@ -84,7 +162,7 @@ object CloudfrontURLSigner {
       }.adaptError { case e => CloudFrontURLSigningCatastrophe(e) }
 
     final class CloudfrontURLSignerImpl[F[_]](
-      private val config:           CloudfrontConfig
+      private val config:           CloudfrontConfig.WithKeyFile
     )(
       implicit private val F:       Sync[F],
       implicit private val blocker: BlockingShifter[F],

--- a/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/CloudfrontURLSigner.scala
+++ b/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/CloudfrontURLSigner.scala
@@ -4,129 +4,81 @@ import busymachines.pureharm.effects._
 import busymachines.pureharm.effects.implicits._
 import busymachines.pureharm.aws.s3._
 
-/**
-  * Either use this for a stable configuration,
-  * or [[CloudfrontURLSigner.signS3KeyCanned]] method on companion
-  * object to be used in various configurations
-  *
-  * @author Lorand Szakacs, https://github.com/lorandszakacs
-  * @since 08 Jul 2019
-  */
+/*
+ * @author Lorand Szakacs, https://github.com/lorandszakacs
+ * @since 08 Jul 2019
+ */
 trait CloudfrontURLSigner[F[_]] {
   def signS3KeyCanned(s3key: S3FileKey): F[CloudfrontSignedURL]
 }
 
 object CloudfrontURLSigner {
+  import java.security.PrivateKey
 
-  def apply[F[_]: Sync: BlockingShifter](config: CloudfrontConfig): Resource[F, CloudfrontURLSigner[F]] =
-    config match {
-      case kf: CloudfrontConfig.WithKeyFile    => new impl.CloudfrontURLSignerImpl[F](kf).pure[Resource[F, *]]
+  def apply[F[_]: Sync: BlockingShifter](config: CloudfrontConfig): Resource[F, CloudfrontURLSigner[F]] = {
+    val privateKeyF: F[PrivateKey] = config match {
+      case kf: CloudfrontConfig.WithKeyFile    =>
+        impl.loadPrivateKeyFromPath[F](kf.privateKeyFilePath)
       case pk: CloudfrontConfig.WithPrivateKey =>
-        for {
-          (keyPath, _) <- Resource.make[F, (CloudfrontPrivateKeyFilePath, java.nio.file.Path)](
-            acquire = init.writePrivateKeyToTempFile[F](pk.privateKey, pk.privateKeyFormat)
-          )(
-            release = {
-              case (kp, td) => init.deletePrivateKeyTempFile[F](td, kp)
-            }
-          )
-          newConfig = CloudfrontConfig.WithKeyFile(
-            distributionDomain = pk.distributionDomain,
-            privateKeyFilePath = keyPath,
-            keyPairID          = pk.keyPairID,
-            urlExpirationTime  = pk.urlExpirationTime,
-          )
-        } yield new impl.CloudfrontURLSignerImpl[F](newConfig)
+        impl.loadPrivateKeyFromMemory[F](pk.privateKeyFormat, pk.privateKey)
     }
 
-  def signS3KeyCanned[F[_]: Sync: BlockingShifter](
-    config: CloudfrontConfig.WithKeyFile
-  )(s3key:  S3FileKey): F[CloudfrontSignedURL] =
     for {
-      baseURL    <- impl.createBaseUrl(config.distributionDomain)(s3key).pure[F]
-      privateKey <- impl.loadPrivateKey[F](config.privateKeyFilePath)
-      expiresAt  <- TimeUtil.computeExpirationDate[F](config.urlExpirationTime)
-      signed     <- impl.signCanned[F](
-        privateKey = privateKey,
-        keyPairID  = config.keyPairID,
-        baseURL    = baseURL,
-        expiresAt  = expiresAt,
-      )
-    } yield CloudfrontSignedURL(signed)
-
-  private object init {
-    import java.nio.file._
-    import java.nio.file.attribute._
-
-    /**
-      * Basically the way this works is that it:
-      *  - create a $folderName with a random name under /tmp
-      *    this folder has permissions 600 (it has to be lower than 644).
-      *    we use a random name in case of server crashes or something,
-      *    so we don't have conflicts.
-      *
-      *  - create a /tmp/$folderName/temp_private_key.${pem or der)
-      *    to store the decoded `privateKey` with permissions 600
-      *
-      *  This permission scheme is how you _have_ to store private keys :)
-      *
-      * @param privateKey
-      *   The private key to be stored in a file
-      *  @param privateKeyFormat
-      *    one of .pem or .der
-      * @return
-      *   The full file path to be read w/ the cloudfront java SDK
-      */
-    def writePrivateKeyToTempFile[F[_]](
-      privateKey:       CloudfrontPrivateKey,
-      privateKeyFormat: CloudfrontPrivateKey.Format,
-    )(implicit
-      F:                Sync[F],
-      bs:               BlockingShifter[F],
-    ): F[(CloudfrontPrivateKeyFilePath, Path)] = {
-
-      val tempDirRoot = Path.of("/tmp")
-      val perms600: java.util.Set[PosixFilePermission] = {
-        val temp = new java.util.HashSet[PosixFilePermission]()
-        temp.add(PosixFilePermission.OWNER_READ);
-        temp.add(PosixFilePermission.OWNER_WRITE);
-        temp
-      }
-      val attr        = PosixFilePermissions.asFileAttribute(perms600)
-      val write       = for {
-        tempDirPath <- F.delay(Files.createTempDirectory(tempDirRoot, "cloudfront_key", attr)) //TODO: adapt errors
-        tempKeyFilePath = Path.of(tempDirRoot.toString, s"temp_private_key${privateKeyFormat.toString}")
-        afterWrite <- F.delay(Files.createTempFile(tempKeyFilePath, null, null, attr))
-        finalPath  <- F.delay[Path](
-          Files.write(afterWrite, privateKey.utf8Bytes, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
-        )
-      } yield (CloudfrontPrivateKeyFilePath(finalPath.toAbsolutePath.toString), tempDirPath)
-
-      bs.blockOn(write)
-    }
-
-    def deletePrivateKeyTempFile[F[_]: Sync: BlockingShifter](
-      tempDirPath: Path,
-      kfp:         CloudfrontPrivateKeyFilePath,
-    ): F[Unit] =
-      BlockingShifter[F].blockOn {
-        Sync[F].delay(Files.delete(Path.of(kfp))) >> Sync[F].delay(Files.delete(tempDirPath))
-      }
-
+      pk <- Resource.liftF(privateKeyF) // Resource.fromDestroyable(privateKey): TODO: upon closing this fails :(
+    } yield new impl.CloudfrontURLSignerImpl(pk, config)
   }
 
   private object impl {
-    import java.security.PrivateKey
     import com.amazonaws.services.cloudfront.CloudFrontUrlSigner
     import com.amazonaws.services.cloudfront.util.SignerUtils
+
+    def signS3KeyCanned[F[_]: Sync: BlockingShifter](
+      privateKey: PrivateKey,
+      config:     CloudfrontConfig,
+    )(s3key:      S3FileKey): F[CloudfrontSignedURL] =
+      for {
+        baseURL   <- impl.createBaseUrl(config.distributionDomain)(s3key).pure[F]
+        expiresAt <- TimeUtil.computeExpirationDate[F](config.urlExpirationTime)
+        signed    <- impl.signCanned[F](
+          privateKey = privateKey,
+          keyPairID  = config.keyPairID,
+          baseURL    = baseURL,
+          expiresAt  = expiresAt,
+        )
+      } yield CloudfrontSignedURL(signed)
 
     /**
       * We have to load private key from fuck-all the way where AWS stores it :/
       * it necessarily needs to be in .DER format.
       * See [[https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CFPrivateDistJavaDevelopment.html]]
       */
-    def loadPrivateKey[F[_]](
-      key:     CloudfrontPrivateKeyFilePath
+    def loadPrivateKeyFromMemory[F[_]](
+      format:  CloudfrontPrivateKey.Format,
+      kp:      CloudfrontPrivateKey,
+    )(implicit
+      F:       Sync[F],
+      blocker: BlockingShifter[F],
+    ): F[PrivateKey] =
+      blocker
+        .delay {
+          import java.io.ByteArrayInputStream
+          val bytes = kp.utf8Bytes
+          format match {
+            case CloudfrontPrivateKey.PEM =>
+              com.amazonaws.auth.PEM.readPrivateKey(new ByteArrayInputStream(bytes)): PrivateKey
+            case CloudfrontPrivateKey.DER =>
+              com.amazonaws.auth.RSA.privateKeyFromPKCS8(bytes): PrivateKey
+          }
+        }
+        .adaptError { case e => CloudFrontKeyReadingCatastrophe(e) }
+
+    /**
+      * We have to load private key from fuck-all the way where AWS stores it :/
+      * it necessarily needs to be in .DER format.
+      * See [[https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CFPrivateDistJavaDevelopment.html]]
+      */
+    def loadPrivateKeyFromPath[F[_]](
+      kp: CloudfrontPrivateKeyFilePath
     )(implicit
       F:       Sync[F],
       blocker: BlockingShifter[F],
@@ -134,7 +86,7 @@ object CloudfrontURLSigner {
       //using this instead of blocker.delay, to ensure that the error is adapted
       //on the same thread loading the private key happens
       blocker.blockOn {
-        F.delay(SignerUtils.loadPrivateKey(key)).adaptError { case e => CloudFrontKeyReadingCatastrophe(e) }
+        F.delay(SignerUtils.loadPrivateKey(kp.toFile)).adaptError { case e => CloudFrontKeyReadingCatastrophe(e) }
       }
 
     /**
@@ -162,14 +114,15 @@ object CloudfrontURLSigner {
       }.adaptError { case e => CloudFrontURLSigningCatastrophe(e) }
 
     final class CloudfrontURLSignerImpl[F[_]](
-      private val config:           CloudfrontConfig.WithKeyFile
+      private val privateKey:       PrivateKey,
+      private val config:           CloudfrontConfig,
     )(
       implicit private val F:       Sync[F],
       implicit private val blocker: BlockingShifter[F],
     ) extends CloudfrontURLSigner[F] {
 
       override def signS3KeyCanned(s3key: S3FileKey): F[CloudfrontSignedURL] =
-        CloudfrontURLSigner.signS3KeyCanned[F](config)(s3key)
+        CloudfrontURLSigner.impl.signS3KeyCanned[F](privateKey, config)(s3key)
     }
   }
 

--- a/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/package.scala
+++ b/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/package.scala
@@ -22,6 +22,8 @@ package object cloudfront {
   object CloudfrontPrivateKeyFilePath extends PhantomType[String]
   type CloudfrontPrivateKeyFilePath = CloudfrontPrivateKeyFilePath.Type
 
+  type CloudfrontPrivateKey = CloudfrontPrivateKey.Type
+
   object CloudfrontKeyPairID extends PhantomType[String]
   /**
     * See [[https://support.s3mediamaestro.com/article/204-how-to-obtain-your-cloudfront-key-pair-id-and-private-key]]

--- a/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/package.scala
+++ b/aws-cloudfront/src/main/scala/busymachines/pureharm/aws/cloudfront/package.scala
@@ -19,7 +19,7 @@ package object cloudfront {
     */
   type CloudfrontDistributionDomain = CloudfrontDistributionDomain.Type
 
-  object CloudfrontPrivateKeyFilePath extends PhantomType[String]
+  object CloudfrontPrivateKeyFilePath extends PhantomType[java.nio.file.Path]
   type CloudfrontPrivateKeyFilePath = CloudfrontPrivateKeyFilePath.Type
 
   type CloudfrontPrivateKey = CloudfrontPrivateKey.Type

--- a/aws-cloudfront/src/test/resources/reference.conf
+++ b/aws-cloudfront/src/test/resources/reference.conf
@@ -1,7 +1,7 @@
 test-config {
   pureharm {
     aws {
-      cloudfront {
+      cloudfront-with-key-path {
         #see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html
         distribution-domain = "test.cloudfront.net"
 
@@ -10,6 +10,38 @@ test-config {
 
         #see https://support.s3mediamaestro.com/article/204-how-to-obtain-your-cloudfront-key-pair-id-and-private-key
         key-pair-id = "test-key-pair-id"
+
+        url-expiration-time = 7 days
+      }
+
+      cloudfront-with-key-value-pem {
+        #see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html
+        distribution-domain = "test.cloudfront.net"
+
+        #see https://support.s3mediamaestro.com/article/204-how-to-obtain-your-cloudfront-key-pair-id-and-private-key
+        key-pair-id = "test-key-pair-id"
+
+        #see https://support.s3mediamaestro.com/article/204-how-to-obtain-your-cloudfront-key-pair-id-and-private-key
+        private-key = "QkxBQkxBQkxB" #base64 encoding of: BLABLABLA
+
+        #AWS only supports .pem or .der formats
+        private-key-format = ".pem"
+
+        url-expiration-time = 7 days
+      }
+
+      cloudfront-with-key-value-der {
+        #see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html
+        distribution-domain = "test.cloudfront.net"
+
+        #see https://support.s3mediamaestro.com/article/204-how-to-obtain-your-cloudfront-key-pair-id-and-private-key
+        key-pair-id = "test-key-pair-id"
+
+        #see https://support.s3mediamaestro.com/article/204-how-to-obtain-your-cloudfront-key-pair-id-and-private-key
+        private-key = "QkxBQkxBQkxB" #base64 encoding of: BLABLABLA
+
+        #AWS only supports .pem or .der formats
+        private-key-format = ".der"
 
         url-expiration-time = 7 days
       }

--- a/aws-cloudfront/src/test/scala/busymachines/pureharm/aws/cloudfront/CloudfrontConfigLoaderTest.scala
+++ b/aws-cloudfront/src/test/scala/busymachines/pureharm/aws/cloudfront/CloudfrontConfigLoaderTest.scala
@@ -1,23 +1,52 @@
 package busymachines.pureharm.aws.cloudfront
 
 import busymachines.pureharm.effects._
-import scala.concurrent.duration._
+import busymachines.pureharm.testkit.PureharmTest
 
-import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration._
 
 /**
   * @author Lorand Szakacs, https://github.com/lorandszakacs
   * @since 19 Jul 2019
   */
-class CloudfrontConfigLoaderTest extends AnyFunSuite {
+final class CloudfrontConfigLoaderTest extends PureharmTest {
 
-  test("load config values") {
-    val configIO = CloudfrontConfig.fromNamespace[IO]("test-config.pureharm.aws.cloudfront")
-    assert(
-      configIO.unsafeRunSync() === CloudfrontConfig(
+  test("load config values — CloudfrontConfig.WithKeyFile") {
+    for {
+      config <- CloudfrontConfig.fromNamespace[IO]("test-config.pureharm.aws.cloudfront-with-key-path")
+    } yield assert(
+      config === CloudfrontConfig.WithKeyFile(
         distributionDomain = CloudfrontDistributionDomain("test.cloudfront.net"),
         privateKeyFilePath = CloudfrontPrivateKeyFilePath("test-key"),
         keyPairID          = CloudfrontKeyPairID("test-key-pair-id"),
+        urlExpirationTime  = CloudfrontURLExpiration(7.days),
+      )
+    )
+  }
+
+  test("load config values — CloudfrontConfig.WithPrivateKey — PEM") {
+    for {
+      config <- CloudfrontConfig.fromNamespace[IO]("test-config.pureharm.aws.cloudfront-with-key-value-pem")
+    } yield assert(
+      config === CloudfrontConfig.WithPrivateKey(
+        distributionDomain = CloudfrontDistributionDomain("test.cloudfront.net"),
+        keyPairID          = CloudfrontKeyPairID("test-key-pair-id"),
+        privateKey         = CloudfrontPrivateKey.unsafe("BLABLABLA"),
+        privateKeyFormat   = CloudfrontPrivateKey.PEM,
+        urlExpirationTime  = CloudfrontURLExpiration(7.days),
+      )
+    )
+  }
+
+  test("load config values — CloudfrontConfig.WithPrivateKey — DER") {
+    for {
+      config <- CloudfrontConfig.fromNamespace[IO]("test-config.pureharm.aws.cloudfront-with-key-value-der")
+    } yield assert(
+      config === CloudfrontConfig.WithPrivateKey(
+        distributionDomain = CloudfrontDistributionDomain("test.cloudfront.net"),
+        keyPairID          = CloudfrontKeyPairID("test-key-pair-id"),
+        privateKey         = CloudfrontPrivateKey.unsafe("BLABLABLA"),
+        privateKeyFormat   = CloudfrontPrivateKey.DER,
         urlExpirationTime  = CloudfrontURLExpiration(7.days),
       )
     )

--- a/aws-cloudfront/src/test/scala/busymachines/pureharm/aws/cloudfront/CloudfrontConfigLoaderTest.scala
+++ b/aws-cloudfront/src/test/scala/busymachines/pureharm/aws/cloudfront/CloudfrontConfigLoaderTest.scala
@@ -17,7 +17,7 @@ final class CloudfrontConfigLoaderTest extends PureharmTest {
     } yield assert(
       config === CloudfrontConfig.WithKeyFile(
         distributionDomain = CloudfrontDistributionDomain("test.cloudfront.net"),
-        privateKeyFilePath = CloudfrontPrivateKeyFilePath("test-key"),
+        privateKeyFilePath = CloudfrontPrivateKeyFilePath(java.nio.file.Path.of("test-key")),
         keyPairID          = CloudfrontKeyPairID("test-key-pair-id"),
         urlExpirationTime  = CloudfrontURLExpiration(7.days),
       )

--- a/build.sbt
+++ b/build.sbt
@@ -184,7 +184,7 @@ lazy val `aws-sns` = project
 //#############################################################################
 //#############################################################################
 
-lazy val pureharmVersion:        String = "0.0.6-M5" //https://github.com/busymachines/pureharm/releases
+lazy val pureharmVersion:        String = "0.0.6-M6" //https://github.com/busymachines/pureharm/releases
 lazy val scalaCollCompatVersion: String = "2.1.6"    //https://github.com/scala/scala-collection-compat/releases
 lazy val monixVersion:           String = "3.2.2"    //https://github.com/monix/monix/releases
 lazy val log4catsVersion:        String = "1.1.1"    //https://github.com/ChristopherDavenport/log4cats/releases


### PR DESCRIPTION
Cloudfront can now receive the signing key as a Base64 encoded `.pem` and `.der` key (the only two formats supported by AWS). That is, you take your key, w/ its `-------- BEGIN....` and encode _that_. and put it in config. We do this to avoid any problems with whitespace.

`CloudfrontConfig` is now a sealed trait with two variants:

```scala
  //just as in previous version, fully backwards compatible when reading
  final case class WithKeyFile(
    override val distributionDomain: CloudfrontDistributionDomain,
    override val keyPairID:          CloudfrontKeyPairID,
    override val urlExpirationTime:  CloudfrontURLExpiration,
    privateKeyFilePath:          CloudfrontPrivateKeyFilePath,
  ) extends CloudfrontConfig

  //adds two fields, the secret itself and the format of the secret, either .pem or .der
  final case class WithPrivateKey(
    override val distributionDomain: CloudfrontDistributionDomain,
    override val keyPairID:          CloudfrontKeyPairID,
    override val urlExpirationTime:  CloudfrontURLExpiration,
    privateKey:                      CloudfrontPrivateKey,
    privateKeyFormat:                CloudfrontPrivateKey.Format,
  ) extends CloudfrontConfig
//new version
```

And that's it, just provide one of the two configs, and the `busymachines.pureharm.aws.cloudfront.CloudfrontURLSigner` will take care of the rest.
